### PR TITLE
refactor: use the new listSubstates method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+*.env

--- a/src/routes/home/Home.tsx
+++ b/src/routes/home/Home.tsx
@@ -78,10 +78,10 @@ function Home() {
             });
 
         const getBadges = wallet.listSubstates(provider, null, "Resource")
-            .then(substates => {
+            .then(resp => {
                 setBadges(
                     // Best guess :/
-                    substates
+                    resp.substates
                         .filter(s => !!s.substate_id.NonFungible)
                         .map(s => s.substate_id.NonFungible.resource_address)
                 );
@@ -94,10 +94,10 @@ function Home() {
                 ? wallet.listSubstates(provider, settings.template, "Component")
                 : Promise.resolve(null)
         )
-            .then(substates => {
-                if (substates?.length) {
+            .then(resp => {
+                if (resp?.substates?.length) {
                     setComponents(
-                        substates
+                        resp.substates
                             .filter(s => !!s.substate_id.Component)
                             .map(s => s.substate_id.Component)
                     );

--- a/src/routes/substates/Substates.tsx
+++ b/src/routes/substates/Substates.tsx
@@ -51,9 +51,9 @@ function Substates() {
     useEffect(() => {
         if (settings) {
             listSubstates(provider, settings.template, "Component")
-                .then(substates => {
+                .then(resp => {
                     setComponents(
-                        substates
+                        resp.substates
                             .filter(s => !!s.substate_id.Component)
                             .map(s => s.substate_id.Component)
                     );

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -24,10 +24,7 @@ export async function listSubstates<T extends TariProvider>(
     if (provider === null) {
         throw new Error('Provider is not initialized');
     }
-    if (provider.providerName !== "WalletDaemon") {
-        throw new Error(`Unsupported provider ${provider.providerName}`);
-    }
-    const substates = await (provider as unknown as WalletDaemonTariProvider).listSubstates(
+    const substates = await provider.listSubstates(
         template,
         substateType
     );


### PR DESCRIPTION
After https://github.com/tari-project/tari.js/pull/16 we now have a common `listSubstates` method for all `tari.js` providers. This PR adapts the template to the latest changes.